### PR TITLE
Added one character to slack reminder.

### DIFF
--- a/lib/API.ts
+++ b/lib/API.ts
@@ -581,7 +581,7 @@ export namespace API {
       await slackClient.chat.postMessage({
         token: process.env.SLACK_KEY,
         channel: process.env.SLACK_CHANNEL,
-        text: `<@${data.slackId}> Please report to our section and prepare for scouting. Sent by ${data.senderSlackId}`,
+        text: `<@${data.slackId}> Please report to our section and prepare for scouting. Sent by @${data.senderSlackId}`,
       });
     },
 


### PR DESCRIPTION
Added an @ to slack reminders in order to actually display the user who sent the reminder, not just their user id.